### PR TITLE
Added Drupal 9 core version requirement field to .info file.

### DIFF
--- a/yaml_editor.info.yml
+++ b/yaml_editor.info.yml
@@ -2,5 +2,6 @@ name: YAML Editor
 type: module
 description: 'Adds an editor for YAML configuration textareas.'
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: Development
 configure: yaml_editor.config


### PR DESCRIPTION
According to Acquia's Drupal 9 compatibility tool: https://dev.acquia.com/drupal9/deprecation_status/errors?project=yaml_editor%201.x-dev this module only requires adding the new `core_version_requirement` field to the .info file to be Drupal 9 compatible.