### PR TITLE
Attach library to widget

### DIFF
--- a/src/Plugin/Field/FieldWidget/YamlEditorWidget.php
+++ b/src/Plugin/Field/FieldWidget/YamlEditorWidget.php
@@ -37,6 +37,11 @@ class YamlEditorWidget extends StringTextareaWidget {
         'data-yaml-editor' => 'true',
         'class' => ['js-text-full', 'text-full'],
       ],
+      '#attached' => [
+        'library' => [
+          'yaml_editor/yaml_editor',
+        ],
+      ],
     ];
 
     return $element;


### PR DESCRIPTION
The library should be attached to the widget so it gets loaded by Drupal when the widget is rendered. Rather than depending on the page attach in the .module file.